### PR TITLE
context menu fix for cosmetic filter

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
+++ b/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
@@ -37,13 +37,15 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
     case 'addBlockElement': {
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs: any) {
         chrome.tabs.sendMessage(tabs[0].id, { type: 'getTargetSelector' }, function (response: any) {
-          if (response) {
-            rule.selector = window.prompt('CSS selector to block: ', `${response}`) || ''
-            chrome.tabs.insertCSS({
-              code: `${rule.selector} {display: none;}`
-            })
-            cosmeticFilterActions.siteCosmeticFilterAdded(rule.host, rule.selector)
+          if (!response) {
+            rule.selector = window.prompt('We were unable to automatically populate a correct CSS selector for you. Please manually enter a CSS selector to block:') || ''
+          } else {
+            rule.selector = window.prompt('CSS selector:', `${response}`) || ''
           }
+          chrome.tabs.insertCSS({
+            code: `${rule.selector} {display: none;}`
+          })
+          cosmeticFilterActions.siteCosmeticFilterAdded(rule.host, rule.selector)
         })
       })
       break


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
